### PR TITLE
Add get_hdus(), silence warnings & implement Display for Image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rayon = "1"
 dyn-clone = "1"
 indexmap = "1"
 rustronomy-core = "0.1"
+anyhow = "1"
 
 [dev-dependencies]
 dirs = "4"

--- a/src/api/fits.rs
+++ b/src/api/fits.rs
@@ -49,6 +49,8 @@
 
 use std::{error::Error, fmt::Display, path::Path};
 
+use anyhow::{Result};
+
 use rustronomy_core::universal_containers::*;
 
 use super::hdu::Hdu;
@@ -60,7 +62,7 @@ pub struct Fits {
 }
 
 impl Fits {
-  pub fn read(path: &Path) -> Result<Self, Box<dyn Error>> {
+  pub fn read(path: &Path) -> Result<Self> {
     //(1) First we try to open the file
     let mut reader = crate::intern::FitsReader::new(path)?;
 
@@ -68,7 +70,7 @@ impl Fits {
     let (global_tags, hdu0) = crate::intern::read_primary_hdu(&mut reader)?;
     todo!()
   }
-  pub fn write(self, path: &Path) -> Result<(), Box<dyn Error>> {
+  pub fn write(self, path: &Path) -> Result<()> {
     todo!()
   }
   pub fn empty() -> Self {

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -22,6 +22,8 @@ use std::{
   fmt::{Display, Formatter},
 };
 
+use anyhow::Result;
+
 use crate::{
   io_err::{self, InvalidFitsFileErr as IFFErr},
   raw::{raw_io::RawFitsWriter, BlockSized},
@@ -72,10 +74,10 @@ impl Display for Extension {
 }
 
 impl Extension {
-  pub(crate) fn write_to_buffer(self, writer: &mut RawFitsWriter) -> Result<(), Box<dyn Error>> {
+  pub(crate) fn write_to_buffer(self, writer: &mut RawFitsWriter) -> Result<()> {
     use Extension::*;
     match self {
-      Corrupted => return Err(Box::new(IFFErr::new(io_err::CORRUPTED))),
+      Corrupted => return Err(IFFErr::new(io_err::CORRUPTED).into()),
       Image(img) => ImgParser::encode_img(img, writer),
       AsciiTable(tbl) => AsciiTblParser::encode_tbl(tbl, writer),
     }

--- a/src/extensions/image/generic_image.rs
+++ b/src/extensions/image/generic_image.rs
@@ -49,6 +49,21 @@ where
   }
 }
 
+impl<T> Display for Image<T>
+where
+  T: Debug + Num + Sized + Decode + Encode + Display + Clone,
+{
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    for (i,&n) in self.shape.iter().enumerate() {
+      if i > 0 {
+	write!(f,"x")?;
+      }
+      write!(f,"{}",n)?;
+    }
+    write!(f,"/{}",self.block_size)
+  }
+}
+
 impl<T> Image<T>
 where
   T: Debug + Num + Sized + Decode + Encode + Display + Clone,

--- a/src/extensions/image/image_parser.rs
+++ b/src/extensions/image/image_parser.rs
@@ -30,6 +30,8 @@ use std::{
   mem::size_of,
 };
 
+use anyhow::Result;
+
 //Rustronomy Imports
 use rustronomy_core::data_type_traits::io_utils::{Decode, Encode};
 
@@ -60,7 +62,7 @@ impl ImgParser {
     reader: &mut RawFitsReader,
     shape: &Vec<usize>,
     bitpix: Bitpix,
-  ) -> Result<Extension, Box<dyn Error>> {
+  ) -> Result<Extension> {
     use Bitpix::*;
     use TypedImage::*;
 
@@ -77,7 +79,7 @@ impl ImgParser {
   fn decode_helper<T>(
     reader: &mut RawFitsReader,
     shape: &Vec<usize>,
-  ) -> Result<Image<T>, Box<dyn Error>>
+  ) -> Result<Image<T>>
   where
     T: Debug + Num + Sized + Decode + Encode + Display + Clone + Send,
   {
@@ -156,7 +158,7 @@ impl ImgParser {
   pub(crate) fn encode_img(
     typed_img: TypedImage,
     writer: &mut RawFitsWriter,
-  ) -> Result<(), Box<dyn Error>> {
+  ) -> Result<()> {
     //This function only matches the typed image and calls the appropriate
     //helper function
     use TypedImage::*;
@@ -174,7 +176,7 @@ impl ImgParser {
     Ok(())
   }
 
-  fn encode_helper<T>(img: Image<T>, writer: &mut RawFitsWriter) -> Result<(), Box<dyn Error>>
+  fn encode_helper<T>(img: Image<T>, writer: &mut RawFitsWriter) -> Result<()>
   where
     T: Debug + Num + Sized + Decode + Encode + Display + Clone,
   {
@@ -207,7 +209,7 @@ impl ImgParser {
         match img.get_data().as_slice_memory_order() {
           None => {
             //Data is NOT continuous, return error!
-            return Err(Box::new(IMLErr::new()));
+            return Err(IMLErr::new().into());
           }
           _ => {} //Data IS continuous, continue!
         }

--- a/src/extensions/image/typed_image.rs
+++ b/src/extensions/image/typed_image.rs
@@ -109,8 +109,16 @@ impl ExtensionPrint for TypedImage {
 
 impl Display for TypedImage {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    //TODO: make pretty display for image!
-    todo!()
+    write!(f,"TypedImage(")?;
+    match self {
+      Self::ByteImg(img) => write!(f,"u16,{}",img)?,
+      Self::I16Img(img)=> write!(f,"i16,{}",img)?,
+      Self::I32Img(img)=> write!(f,"i32,{}",img)?,
+      Self::I64Img(img)=> write!(f,"i64,{}",img)?,
+      Self::SpfImg(img)=> write!(f,"f32,{}",img)?,
+      Self::DpfImg(img)=> write!(f,"f64,{}",img)?,
+    }
+    write!(f,")")
   }
 }
 

--- a/src/extensions/image/typed_image.rs
+++ b/src/extensions/image/typed_image.rs
@@ -22,6 +22,7 @@ use std::{
   fmt::{Display, Write},
 };
 
+use anyhow::Result;
 use ndarray::{Array, IxDyn};
 
 use crate::{
@@ -128,87 +129,87 @@ impl TypedImage {
     }
   }
 
-  pub fn as_u8_array(&self) -> Result<&Array<u8, IxDyn>, Box<dyn Error>> {
+  pub fn as_u8_array(&self) -> Result<&Array<u8, IxDyn>> {
     match &self {
       Self::ByteImg(img) => Ok(img.get_data()),
-      &var => Err(Box::new(WITErr::new(var, Bitpix::byte()))),
+      &var => Err(WITErr::new(var, Bitpix::byte()).into()),
     }
   }
 
-  pub fn as_i16_array(&self) -> Result<&Array<i16, IxDyn>, Box<dyn Error>> {
+  pub fn as_i16_array(&self) -> Result<&Array<i16, IxDyn>> {
     match &self {
       Self::I16Img(img) => Ok(img.get_data()),
-      &var => Err(Box::new(WITErr::new(var, Bitpix::short()))),
+      &var => Err(WITErr::new(var, Bitpix::short()).into()),
     }
   }
 
-  pub fn as_i32_array(&self) -> Result<&Array<i32, IxDyn>, Box<dyn Error>> {
+  pub fn as_i32_array(&self) -> Result<&Array<i32, IxDyn>> {
     match &self {
       Self::I32Img(img) => Ok(img.get_data()),
-      &var => Err(Box::new(WITErr::new(var, Bitpix::int()))),
+      &var => Err(WITErr::new(var, Bitpix::int()).into()),
     }
   }
 
-  pub fn as_i64_array(&self) -> Result<&Array<i64, IxDyn>, Box<dyn Error>> {
+  pub fn as_i64_array(&self) -> Result<&Array<i64, IxDyn>> {
     match &self {
       Self::I64Img(img) => Ok(img.get_data()),
-      &var => Err(Box::new(WITErr::new(var, Bitpix::long()))),
+      &var => Err(WITErr::new(var, Bitpix::long()).into()),
     }
   }
 
-  pub fn as_f32_array(&self) -> Result<&Array<f32, IxDyn>, Box<dyn Error>> {
+  pub fn as_f32_array(&self) -> Result<&Array<f32, IxDyn>> {
     match &self {
       Self::SpfImg(img) => Ok(img.get_data()),
-      &var => Err(Box::new(WITErr::new(var, Bitpix::spf()))),
+      &var => Err(WITErr::new(var, Bitpix::spf()).into()),
     }
   }
 
-  pub fn as_f64_array(&self) -> Result<&Array<f64, IxDyn>, Box<dyn Error>> {
+  pub fn as_f64_array(&self) -> Result<&Array<f64, IxDyn>> {
     match &self {
       Self::DpfImg(img) => Ok(img.get_data()),
-      &var => Err(Box::new(WITErr::new(var, Bitpix::dpf()))),
+      &var => Err(WITErr::new(var, Bitpix::dpf()).into()),
     }
   }
 
-  pub fn as_owned_u8_array(self) -> Result<Array<u8, IxDyn>, Box<dyn Error>> {
+  pub fn as_owned_u8_array(self) -> Result<Array<u8, IxDyn>> {
     match self {
       Self::ByteImg(img) => Ok(img.get_data_owned()),
-      var => Err(Box::new(WITErr::new(&var, Bitpix::byte()))),
+      var => Err(WITErr::new(&var, Bitpix::byte()).into()),
     }
   }
 
-  pub fn as_owned_i16_array(self) -> Result<Array<i16, IxDyn>, Box<dyn Error>> {
+  pub fn as_owned_i16_array(self) -> Result<Array<i16, IxDyn>> {
     match self {
       Self::I16Img(img) => Ok(img.get_data_owned()),
-      var => Err(Box::new(WITErr::new(&var, Bitpix::short()))),
+      var => Err(WITErr::new(&var, Bitpix::short()).into()),
     }
   }
 
-  pub fn as_owned_i32_array(self) -> Result<Array<i32, IxDyn>, Box<dyn Error>> {
+  pub fn as_owned_i32_array(self) -> Result<Array<i32, IxDyn>> {
     match self {
       Self::I32Img(img) => Ok(img.get_data_owned()),
-      var => Err(Box::new(WITErr::new(&var, Bitpix::int()))),
+      var => Err(WITErr::new(&var, Bitpix::int()).into()),
     }
   }
 
-  pub fn as_owned_i64_array(self) -> Result<Array<i64, IxDyn>, Box<dyn Error>> {
+  pub fn as_owned_i64_array(self) -> Result<Array<i64, IxDyn>> {
     match self {
       Self::I64Img(img) => Ok(img.get_data_owned()),
-      var => Err(Box::new(WITErr::new(&var, Bitpix::long()))),
+      var => Err(WITErr::new(&var, Bitpix::long()).into()),
     }
   }
 
-  pub fn as_owned_f32_array(self) -> Result<Array<f32, IxDyn>, Box<dyn Error>> {
+  pub fn as_owned_f32_array(self) -> Result<Array<f32, IxDyn>> {
     match self {
       Self::SpfImg(img) => Ok(img.get_data_owned()),
-      var => Err(Box::new(WITErr::new(&var, Bitpix::spf()))),
+      var => Err(WITErr::new(&var, Bitpix::spf()).into()),
     }
   }
 
-  pub fn as_owned_f64_array(self) -> Result<Array<f64, IxDyn>, Box<dyn Error>> {
+  pub fn as_owned_f64_array(self) -> Result<Array<f64, IxDyn>> {
     match self {
       Self::DpfImg(img) => Ok(img.get_data_owned()),
-      var => Err(Box::new(WITErr::new(&var, Bitpix::dpf()))),
+      var => Err(WITErr::new(&var, Bitpix::dpf()).into()),
     }
   }
 }

--- a/src/extensions/table/ascii_table.rs
+++ b/src/extensions/table/ascii_table.rs
@@ -22,6 +22,8 @@ use std::{
   fmt::{self, Display, Formatter},
 };
 
+use anyhow::Result;
+
 use crate::{
   extensions::ExtensionPrint,
   raw::{table_entry_format::TableEntryFormat, BlockSized},
@@ -138,10 +140,10 @@ impl AsciiTable {
     AsciiTable { cols: cols, block_size: Some(size) }
   }
 
-  pub(crate) fn add_row(&mut self, row: Vec<TableEntry>) -> Result<(), Box<dyn Error>> {
+  pub(crate) fn add_row(&mut self, row: Vec<TableEntry>) -> Result<()> {
     //Adds row to table
     if row.len() != self.cols.len() {
-      return Err(Box::new(ShapeMisMatchErr::new(&row, &self)));
+      return Err(ShapeMisMatchErr::new(&row, &self).into());
     }
 
     //Add row to the table

--- a/src/extensions/table/ascii_tbl_parser.rs
+++ b/src/extensions/table/ascii_tbl_parser.rs
@@ -26,6 +26,8 @@ use std::{
   str::{self, Utf8Error},
 };
 
+use anyhow::Result;
+
 use crate::{
   extensions::{table::column::AsciiCol, Extension},
   raw::{
@@ -49,7 +51,7 @@ impl AsciiTblParser {
     row_index_col_start: Vec<usize>,   //row index where each column starts
     field_format: Vec<String>,         //data format (incl length) of each field
     field_labels: Option<Vec<String>>, //field labels
-  ) -> Result<Extension, Box<dyn Error>> {
+  ) -> Result<Extension> {
     /*  (1)
         Tables are usually pretty small compared to images. Hence it's
         probably ok to read the whole table in one go. We should be careful
@@ -190,7 +192,7 @@ impl AsciiTblParser {
   pub(crate) fn encode_tbl(
     tbl: AsciiTable,
     writer: &mut RawFitsWriter,
-  ) -> Result<(), Box<dyn Error>> {
+  ) -> Result<()> {
     /*  Note:
         This parser assumes that certain necessary keywords to decode a HDU
         containing a table have already been set while encoding the header

--- a/src/fits.rs
+++ b/src/fits.rs
@@ -84,6 +84,10 @@ impl Fits {
     }
     Some(self.hdus.remove(index))
   }
+
+  pub fn get_hdus(&self)->&[HeaderDataUnit] {
+    &self.hdus
+  }
 }
 
 impl BlockSized for Fits {

--- a/src/fits.rs
+++ b/src/fits.rs
@@ -27,6 +27,7 @@ use std::{
   fmt::{Display, Formatter},
   path::Path,
 };
+use anyhow::Result;
 
 use crate::{
   header_data_unit::HeaderDataUnit,
@@ -42,7 +43,7 @@ pub struct Fits {
 }
 
 impl Fits {
-  pub fn open(path: &Path) -> Result<Self, Box<dyn Error>> {
+  pub fn open<P:AsRef<Path>>(path: P) -> Result<Self> {
     //(1) Construct a RawFitsReader
     let mut reader = RawFitsReader::new(path)?;
 
@@ -57,7 +58,7 @@ impl Fits {
     Ok(Fits { hdus: hdus })
   }
 
-  pub fn write(self, path: &Path) -> Result<(), Box<dyn Error>> {
+  pub fn write(self, path: &Path) -> Result<()> {
     //(1) Construct a RawFitsWriter
     let mut writer = RawFitsWriter::new(path)?;
 

--- a/src/header_data_unit.rs
+++ b/src/header_data_unit.rs
@@ -19,6 +19,7 @@
 
 use core::fmt;
 use std::{borrow::Cow, error::Error, fmt::Display};
+use anyhow::Result;
 
 use crate::{
   bitpix::Bitpix,
@@ -44,7 +45,7 @@ impl HeaderDataUnit {
       INTERNAL CODE
   */
 
-  pub(crate) fn decode_hdu(raw: &mut RawFitsReader) -> Result<Self, Box<dyn Error>> {
+  pub(crate) fn decode_hdu(raw: &mut RawFitsReader) -> Result<Self> {
     //(1) Read the header
     let header = Header::decode_header(raw)?;
 
@@ -84,7 +85,7 @@ impl HeaderDataUnit {
     Ok(HeaderDataUnit { header: header, data: extension })
   }
 
-  fn read_table(raw: &mut RawFitsReader, header: &Header) -> Result<Extension, Box<dyn Error>> {
+  fn read_table(raw: &mut RawFitsReader, header: &Header) -> Result<Extension> {
     /*
         To parse a table we need to know the following keywords:
             TFIELDS => #fields in a row
@@ -163,7 +164,7 @@ impl HeaderDataUnit {
               ttype_keyword.pop();
               header.get_value_as(ttype_keyword.trim())
             })
-            .collect::<Result<Vec<String>, Box<dyn Error>>>()?,
+            .collect::<Result<Vec<String>>>()?,
         )
       }
     };
@@ -183,7 +184,7 @@ impl HeaderDataUnit {
     Ok(tbl)
   }
 
-  fn read_img(raw: &mut RawFitsReader, header: &Header) -> Result<Extension, Box<dyn Error>> {
+  fn read_img(raw: &mut RawFitsReader, header: &Header) -> Result<Extension> {
     //Let's start by getting the number of axes from the NAXIS keyword
     let naxis: usize = header.get_value_as("NAXIS")?;
 
@@ -200,7 +201,7 @@ impl HeaderDataUnit {
     Ok(ImgParser::decode_img(raw, &axes, bitpix)?)
   }
 
-  pub(crate) fn encode_hdu(self, writer: &mut RawFitsWriter) -> Result<(), Box<dyn Error>> {
+  pub(crate) fn encode_hdu(self, writer: &mut RawFitsWriter) -> Result<()> {
     //(1) Write header
     self.header.encode_header(writer)?;
 

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,6 +1,8 @@
 //Std imports
 use std::error::Error;
 
+use anyhow::Result;
+
 //external imports
 use rustronomy_core::universal_containers::*;
 
@@ -27,7 +29,7 @@ pub struct FitsOptions {
 
 pub fn read_primary_hdu(
   reader: &mut FitsReader,
-) -> Result<(meta_only::MetaOnly, Hdu), Box<dyn Error>> {
+) -> Result<(meta_only::MetaOnly, Hdu)> {
   //Max. number of records in a FITS block
   const MAX_RECS: usize = crate::BLOCK_SIZE / crate::RECORD_SIZE;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@
     along with rustronomy.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+
 //Module structure
 mod bitpix;
 mod err;

--- a/src/raw/header_block.rs
+++ b/src/raw/header_block.rs
@@ -18,6 +18,7 @@
 */
 
 use std::error::Error;
+use anyhow::Result;
 
 use crate::header_err::{self, HeaderBlockBufferErr as HBBErr};
 
@@ -66,14 +67,14 @@ impl HeaderBlock {
     return Ok((HeaderBlock { records: records }, is_final));
   }
 
-  pub(crate) fn encode_fill_buff(self, buf: &mut Vec<u8>) -> Result<(), Box<dyn Error>> {
+  pub(crate) fn encode_fill_buff(self, buf: &mut Vec<u8>) -> Result<()> {
     for record in self.records {
       record.encode_fill_buff(buf)?;
     }
     Ok(())
   }
 
-  pub(crate) fn encode_to_bytes(self) -> Result<Vec<u8>, Box<dyn Error>> {
+  pub(crate) fn encode_to_bytes(self) -> Result<Vec<u8>> {
     //Fill buf with data
     let mut buf: Vec<u8> = Vec::new();
     self.encode_fill_buff(&mut buf)?;
@@ -84,7 +85,7 @@ impl HeaderBlock {
       buf.append(&mut vec![0u8; 2880 - buf.len()]);
       return Ok(buf);
     } else if buf.len() > 2880 {
-      return Err(Box::new(HBBErr::new(header_err::BUFFER_LEN)));
+      return Err(HBBErr::new(header_err::BUFFER_LEN).into());
     } else {
       return Ok(buf);
     }

--- a/src/raw/keyword_record.rs
+++ b/src/raw/keyword_record.rs
@@ -23,6 +23,7 @@ use std::{
   rc::Rc,
   str,
 };
+use anyhow::Result;
 
 use crate::keyword_err::{self, KeywordRecordBufferErr as KRBufErr, ProtectedKeywordErr as PKWErr};
 use rustronomy_core::data_type_traits::io_utils::Encode;
@@ -193,7 +194,7 @@ impl KeywordRecord {
     })
   }
 
-  pub(crate) fn encode_fill_buff(self, buf: &mut Vec<u8>) -> Result<(), Box<dyn Error>> {
+  pub(crate) fn encode_fill_buff(self, buf: &mut Vec<u8>) -> Result<()> {
     //keep track of how long the last keyword is
     let mut one_rec_buf = Vec::new();
 


### PR DESCRIPTION
- Add `get_hdus()` that returns a reference to the slice of HDUs
- Silence warnings about dead code and unused imports and variables (a clean-up would be better of course)
- Implement a basic Display for Image and GenericImage, this displays a double-precision, 640 row by 512 column image as `TypedImage(f64,640x512/911)` where `/911` is the block size (not sure if that's useful.)
